### PR TITLE
Fix oaDOI error

### DIFF
--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -57,8 +57,8 @@ function islandora_oadoi_block_view($delta = '') {
             $request_url = $url . $doi;
 
             // Make the request and get results!
-            $result_json = file_get_contents($request_url);
-            $result_array = json_decode($result_json, TRUE);
+            $result_json = drupal_http_request($request_url);
+            $result_array = json_decode($result_json->data, TRUE);
             $result_free_url = $result_array['results'][0]['free_fulltext_url'];
           }
         }

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -57,7 +57,7 @@ function islandora_oadoi_block_view($delta = '') {
             $request_url = $url . $doi;
 
             // Make the request and get results!
-            $result_json = drupal_http_request($request_url);
+            $result_json = file_get_contents($request_url);
             $result_array = json_decode($result_json, TRUE);
             $result_free_url = $result_array['results'][0]['free_fulltext_url'];
           }

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -57,9 +57,11 @@ function islandora_oadoi_block_view($delta = '') {
             $request_url = $url . $doi;
 
             // Make the request and get results!
-            $result_json = drupal_http_request($request_url);
-            $result_array = json_decode($result_json->data, TRUE);
-            $result_free_url = $result_array['results'][0]['free_fulltext_url'];
+            if (!isset($result_json->error)) {
+              $result_json = drupal_http_request($request_url);
+              $result_array = json_decode($result_json->data, TRUE);
+              $result_free_url = $result_array['results'][0]['free_fulltext_url'];
+            }
           }
         }
       }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2020)

# What does this Pull Request do?
Fixes the error resulting from changing file_get_contents() with drupal_http_request() in the oaDOI module. drupal_http_request() throws an error when generating an oaDOI download block.

# How should this be tested?

* Create an object with DOI for an object that does have a free oaDOI URL (e.g. http://doi.wiley.com/10.1111/eva.12339)
* On base branch, view the object; note that no block is generated, warning is shown
* On new branch, see that block appears as expected

# Interested parties
@Islandora/7-x-1-x-committers @qadan @whikloj @bryjbrown 
