### PR TITLE
Fix oadoi error check

### DIFF
--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -57,8 +57,8 @@ function islandora_oadoi_block_view($delta = '') {
             $request_url = $url . $doi;
 
             // Make the request and get results!
-            if (!isset($result_json->error)) {
               $result_json = drupal_http_request($request_url);
+            if (!isset($result_json->error)) {
               $result_array = json_decode($result_json->data, TRUE);
               $result_free_url = $result_array['results'][0]['free_fulltext_url'];
             }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2061)

# What does this Pull Request do?
Moves the error check in the oaDOI module from before the data is requested to after. 

I thought I had already fixed this, but found an uncommitted file in my Vagrant machine that says I didn't.

# How should this be tested?

* Create a Citation object with a good DOI that is available in the oaDOI database (example: 10.1111/eva.12339)
* Create an object with a bad DOI 
* Make sure the oaDOI badge displays as expecated

@Islandora/7-x-1-x-committers
