### PR TITLE
Check configured content models before displaying badges

### DIFF
--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -48,30 +48,32 @@ function islandora_scopus_block_view($delta = '') {
     if ($api_key) {
       $object = menu_get_object('islandora_object', 2);
       if ($object) {
-        $doi = islandora_badges_get_doi($object);
-        if ($doi) {
-          $id = islandora_scopus_get_id('doi', $doi);
-        }
-        // TODO: Extend to allow PMID, etc.
-        if (isset($id)) {
-          $headers = array('Accept' => 'text/html', 'X-ELS-APIKey' => $api_key);
-          $data = http_build_query(array(
-            'scopus_id' => $id,
-            'apiKey' => $api_key,
-            'httpAccept' => 'text/html',
-          ));
-          $scopus_url = "http://api.elsevier.com:80/content/abstract/citation-count?{$data}";
-          $response = drupal_http_request($scopus_url, array('headers' => $headers));
-          // Hit the API.
-          if ($response->code == 200) {
-            if (!preg_match('/alt=\"unavailable\"/', $response->data)) {
-              $to_render['content']['islandora_scopus'] = array(
-                '#type' => 'container',
-                '#attributes' => array(
-                  'class' => 'islandora_scopus_embed',
-                ),
-                '#children' => $response->data,
-              );
+        if (islandora_badges_show_for_cmodel($object)) {
+          $doi = islandora_badges_get_doi($object);
+          if ($doi) {
+            $id = islandora_scopus_get_id('doi', $doi);
+          }
+          // TODO: Extend to allow PMID, etc.
+          if (isset($id)) {
+            $headers = ['Accept' => 'text/html', 'X-ELS-APIKey' => $api_key];
+            $data = http_build_query([
+              'scopus_id' => $id,
+              'apiKey' => $api_key,
+              'httpAccept' => 'text/html',
+            ]);
+            $scopus_url = "http://api.elsevier.com:80/content/abstract/citation-count?{$data}";
+            $response = drupal_http_request($scopus_url, ['headers' => $headers]);
+            // Hit the API.
+            if ($response->code == 200) {
+              if (!preg_match('/alt=\"unavailable\"/', $response->data)) {
+                $to_render['content']['islandora_scopus'] = [
+                  '#type' => 'container',
+                  '#attributes' => [
+                    'class' => 'islandora_scopus_embed',
+                  ],
+                  '#children' => $response->data,
+                ];
+              }
             }
           }
         }

--- a/modules/islandora_wos/islandora_wos.module
+++ b/modules/islandora_wos/islandora_wos.module
@@ -103,7 +103,7 @@ EOB;
               $xpath = new DOMXPath($wos_doc);
               $xpath->registerNamespace('wos', 'http://www.isinet.com/xrpc42');
 
-              // Default - citing_articles_url - no citing articles = empty array.
+              // citing_articles_url - no citing articles = empty array.
               $citing_articles_url = [];
 
               // XPaths based on

--- a/modules/islandora_wos/islandora_wos.module
+++ b/modules/islandora_wos/islandora_wos.module
@@ -50,15 +50,16 @@ function islandora_wos_block_view($delta = '') {
     if (!empty($wos_username) && !empty($wos_password)) {
       $object = menu_get_object('islandora_object', 2);
       if ($object) {
-        $doi = islandora_badges_get_doi($object);
-        if ($doi) {
-          // Embed Web of Science.
-          // Set API endpoint URL.
-          // @TODO: Add to admin form.
-          $url = "https://ws.isiknowledge.com/cps/xrpc";
+        if (islandora_badges_show_for_cmodel($object)) {
+          $doi = islandora_badges_get_doi($object);
+          if ($doi) {
+            // Embed Web of Science.
+            // Set API endpoint URL.
+            // @TODO: Add to admin form.
+            $url = "https://ws.isiknowledge.com/cps/xrpc";
 
-          // Store XML Request in string, as I can't send an XML file by POST.
-          $input_xml = <<<EOB
+            // Store XML Request in string, as I can't send an XML file by POST.
+            $input_xml = <<<EOB
 <?xml version="1.0" encoding="UTF-8" ?>
 <request xmlns="http://www.isinet.com/xrpc42" src="app.id=">
     <fn name="LinksAMR.retrieve">
@@ -86,81 +87,82 @@ function islandora_wos_block_view($delta = '') {
 </request>
 EOB;
 
-          // Post the request and get results!
-          $result = drupal_http_request($url, array(
-            'headers' => array('Content-Type' => 'text/xml'),
-            'data' => $input_xml,
-            'method' => 'POST',
-            'timeout' => 10,
-          )
-          );
+            // Post the request and get results!
+            $result = drupal_http_request($url, [
+                'headers' => ['Content-Type' => 'text/xml'],
+                'data' => $input_xml,
+                'method' => 'POST',
+                'timeout' => 10,
+              ]
+            );
 
-          if (!isset($result->error)) {
-            // Convert the response to an array and remove the CDATA tags.
-            $wos_doc = new DOMDocument();
-            $wos_doc->loadXML($result->data);
-            $xpath = new DOMXPath($wos_doc);
-            $xpath->registerNamespace('wos', 'http://www.isinet.com/xrpc42');
+            if (!isset($result->error)) {
+              // Convert the response to an array and remove the CDATA tags.
+              $wos_doc = new DOMDocument();
+              $wos_doc->loadXML($result->data);
+              $xpath = new DOMXPath($wos_doc);
+              $xpath->registerNamespace('wos', 'http://www.isinet.com/xrpc42');
 
-            // Default - citing_articles_url - no citing articles = empty array.
-            $citing_articles_url = array();
+              // Default - citing_articles_url - no citing articles = empty array.
+              $citing_articles_url = [];
 
-            // XPaths based on
-            // http://ipscience-help.thomsonreuters.com/LAMRService/
-            // WebServiceOperationsGroup/responseAPIWoS.html
-            $citations = $xpath->query("/wos:response/wos:fn/wos:map/wos:map[@name=\"cite_1\"]/wos:map[@name=\"WOS\"]");
-            if ($citations->length > 0) {
-              $context = $citations->item(0);
-              $times_cited_node = $xpath->query("wos:val[@name=\"timesCited\"]", $context);
-              if ($times_cited_node->length > 0) {
-                $times_cited = $times_cited_node->item(0)->textContent;
+              // XPaths based on
+              // http://ipscience-help.thomsonreuters.com/LAMRService/
+              // WebServiceOperationsGroup/responseAPIWoS.html
+              $citations = $xpath->query("/wos:response/wos:fn/wos:map/wos:map[@name=\"cite_1\"]/wos:map[@name=\"WOS\"]");
+              if ($citations->length > 0) {
+                $context = $citations->item(0);
+                $times_cited_node = $xpath->query("wos:val[@name=\"timesCited\"]", $context);
+                if ($times_cited_node->length > 0) {
+                  $times_cited = $times_cited_node->item(0)->textContent;
+                }
+                $citing_articles_url_node = $xpath->query("wos:val[@name=\"citingArticlesURL\"]", $context);
+                if ($citing_articles_url_node->length > 0) {
+                  $citing_articles_url = $citing_articles_url_node->item(0)->textContent;
+                }
               }
-              $citing_articles_url_node = $xpath->query("wos:val[@name=\"citingArticlesURL\"]", $context);
-              if ($citing_articles_url_node->length > 0) {
-                $citing_articles_url = $citing_articles_url_node->item(0)->textContent;
-              }
-            }
 
-            // If there is no error, return data.
-            if (isset($times_cited) && $times_cited > 0) {
-              $badge_type = variable_get('islandora_wos_badgetype');
-              if ($badge_type == 'text') {
-                $badge = array(
-                  '#type' => 'link',
-                  '#title' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
-                  '#href' => $citing_articles_url,
-                  '#options' => array(
-                    'target' => '_blank',
-                  ),
-                );
-              }
-              else {
-                $img = array(
-                  '#theme' => 'image',
-                  '#path' => format_string(
-                    'https://img.shields.io/badge/Web%20of%20Science%20citations-!times_cited-orange.svg?style=flat',
-                    array('!times_cited' => $times_cited)
-                  ),
-                  '#alt' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
-                );
-                $badge = array(
-                  '#type' => 'link',
-                  '#title' => drupal_render($img),
-                  '#href' => $citing_articles_url,
-                  '#options' => array(
-                    'target' => '_blank',
-                    'html' => TRUE,
-                  ),
-                );
+              // If there is no error, return data.
+              if (isset($times_cited) && $times_cited > 0) {
+                $badge_type = variable_get('islandora_wos_badgetype');
+                if ($badge_type == 'text') {
+                  $badge = [
+                    '#type' => 'link',
+                    '#title' => t('Web of Science citations: @cites', ['@cites' => $times_cited]),
+                    '#href' => $citing_articles_url,
+                    '#options' => [
+                      'target' => '_blank',
+                    ],
+                  ];
+                }
+                else {
+                  $img = [
+                    '#theme' => 'image',
+                    '#path' => format_string(
+                      'https://img.shields.io/badge/Web%20of%20Science%20citations-!times_cited-orange.svg?style=flat',
+                      ['!times_cited' => $times_cited]
+                    ),
+                    '#alt' => t('Web of Science citations: @cites', ['@cites' => $times_cited]),
+                  ];
+                  $badge = [
+                    '#type' => 'link',
+                    '#title' => drupal_render($img),
+                    '#href' => $citing_articles_url,
+                    '#options' => [
+                      'target' => '_blank',
+                      'html' => TRUE,
+                    ],
+                  ];
 
+                }
+                $to_render['content']['islandora_wos'] = [
+                  '#type' => 'container',
+                  '#attributes' => [
+                    'class' => 'islandora_wos_embed',
+                  ],
+                  'badge' => $badge,
+                ];
               }
-              $to_render['content']['islandora_wos'] = array(
-                '#type' => 'container',
-                '#attributes' => array(
-                  'class' => 'islandora_wos_embed',
-                ),
-                'badge' => $badge,
-              );
             }
           }
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2092

# What does this Pull Request do?

There is a configured list of which content models to display a badge on, this list is only checked for the Crossref, OADoi and Altmetrics badges. This extends the check to cover the last two badges, Scopus and Web of Science.

# What's new?
Previously a Web Of Science badge check would occur on all content models, now the object must have a content model that was selected in the Badges admin.

# How should this be tested?

Before PR:
1. Add a Web Of Science, Scopus and Altmetrics badge to an object. Configure the allowed content models in the Islandora Badges to include this object's content model.
1. View the 3 badges 
1. Remove the content model from the list.
1. View only 2 badges.

After PR:
1. Add a Web Of Science, Scopus and Altmetrics badge to an object. Configure the allowed content models in the Islandora Badges to include this object's content model.
1. View the 3 badges 
1. Remove the content model from the list.
1. View no badges. 'Cause we don't need no stinking badges.

Example:
* Does this change require documentation to be updated? Yes, as per [this comment](https://github.com/Islandora/islandora_badges/pull/9/files#r146382326)
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? Not that I can see.

# Interested parties
@bondjimbond , @Islandora/7-x-1-x-committers
