### PR TITLE
Xpath helptext

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configuration path is admin/islandora/tools/badges (Administration > Islandora >
 There are two administration fields:
 
 * DOI XPath
-     * The XPath to the DOI element e.g. /mods:mods/mods:identifier[@type="doi"] 
+     * The XPath to the DOI element e.g. /mods:mods/mods:identifier[@type="doi"] Note that XPATH is case-sensitive.
      * A default is included and should serve most repositories, but you can change it if yours is located elsewhere.
 * Content models
      * Choose which CModels are able to display badges.

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -18,7 +18,7 @@ function islandora_badges_admin_form($form, $form_settings) {
   $form['islandora_badges_doi_xpath'] = array(
     '#type' => 'textfield',
     '#title' => t('DOI XPath'),
-    '#description' => t('MODS XPath for retrieving the DOI.'),
+    '#description' => t('MODS XPath for retrieving the DOI. Note that XPATH is case sensitive.'),
     '#default_value' => variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]'),
   );
 


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2098)

# What does this Pull Request do?
Adds helptext to the admin form to note that XPATH is case sensitive.

# What's new?
ISLANDORA-2098 notes that the default XPATH fails to capture instances where a repository has inconsistent case in the "type" attribute. Given that inconsistent metadata is not something we'd want to encourage by default but also not something we'd want to punish, compromise is to add some helptext to remind people that XPATH is case-sensitive.

# How should this be tested?

Adds no new functionality; shouldn't break anything.


# Additional Notes:
Would be nice to add more in-depth notes on the case issue in the wiki entry, perhaps using the XPATH suggested in ISLANDORA-2098 as an example for dealing with inconsistently-applied metadata.

# Interested parties
@bryjbrown @DiegoPino @Islandora/7-x-1-x-committers
