### PR TITLE
Adds default value to 'islandora_wos_badgetype' variable

### DIFF
--- a/modules/islandora_wos/islandora_wos.module
+++ b/modules/islandora_wos/islandora_wos.module
@@ -124,7 +124,7 @@ EOB;
 
               // If there is no error, return data.
               if (isset($times_cited) && $times_cited > 0) {
-                $badge_type = variable_get('islandora_wos_badgetype');
+                $badge_type = variable_get('islandora_wos_badgetype', 'image');
                 if ($badge_type == 'text') {
                   $badge = [
                     '#type' => 'link',


### PR DESCRIPTION
**JIRA Ticket**: 
- https://jira.duraspace.org/browse/ISLANDORA-2134
- https://jira.duraspace.org/browse/ISLANDORA-2121

# What does this Pull Request do?
Adds a default value to `variable_get('islandora_wos_badgetype')` to make it `variable_get('islandora_wos_badgetype', 'image')`. The `image` default value was chosen because it is used in the admin menu: https://github.com/Islandora/islandora_badges/blob/7.x/modules/islandora_wos/includes/admin.form.inc#L31

# How should this be tested?
I'm not really sure, I've never used the WOS badge before because my institution doesn't have an account so I have no username/password to enter, but I'm sure @bondjimbond would know how to test it.

# Interested parties
@bondjimbond @Islandora/7-x-1-x-committers
