### PR TITLE
ISLANDORA-2164: Update Scopus API URL to HTTPS version

### DIFF
--- a/modules/islandora_scopus/includes/admin.form.inc
+++ b/modules/islandora_scopus/includes/admin.form.inc
@@ -9,6 +9,12 @@
  * Admin form for API key.
  */
 function islandora_scopus_admin_form($form, &$form_state) {
+  $form['islandora_scopus_api_endpoint'] = array(
+        '#type' => 'textfield',
+    '#title' => t('Scopus API Endpoint'),
+    '#description' => t('Scopus query URL. Only change this if Elsevier notifies you that it has changed.'),
+    '#default_value' => variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count'),
+  );
   $form['islandora_scopus_api_key'] = array(
     '#type' => 'textfield',
     '#title' => t('Scopus API Key'),

--- a/modules/islandora_scopus/includes/admin.form.inc
+++ b/modules/islandora_scopus/includes/admin.form.inc
@@ -10,7 +10,7 @@
  */
 function islandora_scopus_admin_form($form, &$form_state) {
   $form['islandora_scopus_api_endpoint'] = array(
-        '#type' => 'textfield',
+    '#type' => 'textfield',
     '#title' => t('Scopus API Endpoint'),
     '#description' => t('Scopus query URL. Only change this if Elsevier notifies you that it has changed.'),
     '#default_value' => variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count'),

--- a/modules/islandora_scopus/includes/admin.form.inc
+++ b/modules/islandora_scopus/includes/admin.form.inc
@@ -12,7 +12,8 @@ function islandora_scopus_admin_form($form, &$form_state) {
   $form['islandora_scopus_api_endpoint'] = array(
     '#type' => 'textfield',
     '#title' => t('Scopus API Endpoint'),
-    '#description' => t('Scopus query URL. Only change this if Elsevier notifies you that it has changed.'),
+    '#description' => t('Scopus query URL. Currently https://github.com/Islandora/islandora_badges/pull/15.
+    Only change this if Elsevier notifies you that it has changed.'),
     '#default_value' => variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count'),
   );
   $form['islandora_scopus_api_key'] = array(

--- a/modules/islandora_scopus/includes/admin.form.inc
+++ b/modules/islandora_scopus/includes/admin.form.inc
@@ -12,7 +12,7 @@ function islandora_scopus_admin_form($form, &$form_state) {
   $form['islandora_scopus_api_endpoint'] = array(
     '#type' => 'textfield',
     '#title' => t('Scopus API Endpoint'),
-    '#description' => t('Scopus query URL. Currently https://github.com/Islandora/islandora_badges/pull/15.
+    '#description' => t('Scopus query URL. Currently https://api.elsevier.com/content/abstract/citation-count.
     Only change this if Elsevier notifies you that it has changed.'),
     '#default_value' => variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count'),
   );

--- a/modules/islandora_scopus/islandora_scopus.install
+++ b/modules/islandora_scopus/islandora_scopus.install
@@ -11,6 +11,7 @@
 function islandora_scopus_uninstall() {
   $vars = array(
     'islandora_scopus_api_key',
+    'islandora_scopus_api_endpoint',
   );
   array_walk($vars, 'variable_del');
 }

--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -61,7 +61,9 @@ function islandora_scopus_block_view($delta = '') {
               'apiKey' => $api_key,
               'httpAccept' => 'text/html',
             ]);
-            $scopus_url = "https://api.elsevier.com/content/abstract/citation-count?{$data}";
+            $scopus_endpoint = variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count');
+print_r($scopus_endpoint);
+            $scopus_url = $scopus_endpoint . '?{$data}';
             $response = drupal_http_request($scopus_url, ['headers' => $headers]);
             // Hit the API.
             if ($response->code == 200) {

--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -62,9 +62,8 @@ function islandora_scopus_block_view($delta = '') {
               'httpAccept' => 'text/html',
             ]);
             $scopus_endpoint = variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count');
-print_r($scopus_endpoint);
-            $scopus_url = $scopus_endpoint . '?{$data}';
-            $response = drupal_http_request($scopus_url, ['headers' => $headers]);
+            $scopus_query = $scopus_endpoint . '?' . $data;
+            $response = drupal_http_request($scopus_query, ['headers' => $headers]);
             // Hit the API.
             if ($response->code == 200) {
               if (!preg_match('/alt=\"unavailable\"/', $response->data)) {

--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -61,7 +61,7 @@ function islandora_scopus_block_view($delta = '') {
               'apiKey' => $api_key,
               'httpAccept' => 'text/html',
             ]);
-            $scopus_url = "http://api.elsevier.com:80/content/abstract/citation-count?{$data}";
+            $scopus_url = "https://api.elsevier.com/content/abstract/citation-count?{$data}";
             $response = drupal_http_request($scopus_url, ['headers' => $headers]);
             // Hit the API.
             if ($response->code == 200) {


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2164)

# What does this Pull Request do?

Updates the Scopus API URL to the current HTTPS version. Required by Elsevier - HTTP to be phased out by end of month.

# What's new?
Just the API endpoint.

# How should this be tested?
- Enable the module, enable the block
- Ingest an object with a DOI that returns Scopus citation badge on the original branch
- Check out this branch, clear cache
- Confirm that badge still appears

# Additional Notes:
Versions of the module without this update will stop working in April 2018.

# Interested parties
@Islandora/7-x-1-x-committers
