### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -66,7 +66,7 @@ function islandora_scopus_block_view($delta = '') {
             // Hit the API.
             if ($response->code == 200) {
               if (!preg_match('/alt=\"unavailable\"/', $response->data)) {
-                $to_render['content']['islandora_scopus'] = array( 
+                $to_render['content']['islandora_scopus'] = array(
                   '#type' => 'container',
                   '#attributes' => array(
                     'class' => 'islandora_scopus_embed',

--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -64,7 +64,6 @@ function islandora_scopus_block_view($delta = '') {
             $scopus_endpoint = variable_get('islandora_scopus_api_endpoint', 'https://api.elsevier.com/content/abstract/citation-count');
             $scopus_query = $scopus_endpoint . '?' . $data;
             $response = drupal_http_request($scopus_query, array('headers' => $headers));
-            
             // Hit the API.
             if ($response->code == 200) {
               if (!preg_match('/alt=\"unavailable\"/', $response->data)) {

--- a/modules/islandora_scopus/islandora_scopus.module
+++ b/modules/islandora_scopus/islandora_scopus.module
@@ -55,24 +55,24 @@ function islandora_scopus_block_view($delta = '') {
           }
           // TODO: Extend to allow PMID, etc.
           if (isset($id)) {
-            $headers = ['Accept' => 'text/html', 'X-ELS-APIKey' => $api_key];
-            $data = http_build_query([
+            $headers = array('Accept' => 'text/html', 'X-ELS-APIKey' => $api_key);
+            $data = http_build_query(array(
               'scopus_id' => $id,
               'apiKey' => $api_key,
               'httpAccept' => 'text/html',
-            ]);
+            ));
             $scopus_url = "http://api.elsevier.com:80/content/abstract/citation-count?{$data}";
-            $response = drupal_http_request($scopus_url, ['headers' => $headers]);
+            $response = drupal_http_request($scopus_url, array('headers' => $headers));
             // Hit the API.
             if ($response->code == 200) {
               if (!preg_match('/alt=\"unavailable\"/', $response->data)) {
-                $to_render['content']['islandora_scopus'] = [
+                $to_render['content']['islandora_scopus'] = array( 
                   '#type' => 'container',
-                  '#attributes' => [
+                  '#attributes' => array(
                     'class' => 'islandora_scopus_embed',
-                  ],
+                  ),
                   '#children' => $response->data,
-                ];
+                );
               }
             }
           }

--- a/modules/islandora_wos/islandora_wos.module
+++ b/modules/islandora_wos/islandora_wos.module
@@ -88,7 +88,7 @@ function islandora_wos_block_view($delta = '') {
 EOB;
 
             // Post the request and get results!
-            $result = drupal_http_request($url, array( 
+            $result = drupal_http_request($url, array(
                 'headers' => array('Content-Type' => 'text/xml'),
                 'data' => $input_xml,
                 'method' => 'POST',
@@ -126,7 +126,7 @@ EOB;
               if (isset($times_cited) && $times_cited > 0) {
                 $badge_type = variable_get('islandora_wos_badgetype');
                 if ($badge_type == 'text') {
-                  $badge = array( 
+                  $badge = array(
                     '#type' => 'link',
                     '#title' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
                     '#href' => $citing_articles_url,
@@ -144,11 +144,11 @@ EOB;
                     ),
                     '#alt' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
                   );
-                  $badge = array( 
+                  $badge = array(
                     '#type' => 'link',
                     '#title' => drupal_render($img),
                     '#href' => $citing_articles_url,
-                    '#options' => array( 
+                    '#options' => array(
                       'target' => '_blank',
                       'html' => TRUE,
                     ),

--- a/modules/islandora_wos/islandora_wos.module
+++ b/modules/islandora_wos/islandora_wos.module
@@ -88,12 +88,12 @@ function islandora_wos_block_view($delta = '') {
 EOB;
 
             // Post the request and get results!
-            $result = drupal_http_request($url, [
-                'headers' => ['Content-Type' => 'text/xml'],
+            $result = drupal_http_request($url, array( 
+                'headers' => array('Content-Type' => 'text/xml'),
                 'data' => $input_xml,
                 'method' => 'POST',
                 'timeout' => 10,
-              ]
+              )
             );
 
             if (!isset($result->error)) {
@@ -104,7 +104,7 @@ EOB;
               $xpath->registerNamespace('wos', 'http://www.isinet.com/xrpc42');
 
               // citing_articles_url - no citing articles = empty array.
-              $citing_articles_url = [];
+              $citing_articles_url = array();
 
               // XPaths based on
               // http://ipscience-help.thomsonreuters.com/LAMRService/
@@ -126,42 +126,42 @@ EOB;
               if (isset($times_cited) && $times_cited > 0) {
                 $badge_type = variable_get('islandora_wos_badgetype');
                 if ($badge_type == 'text') {
-                  $badge = [
+                  $badge = array( 
                     '#type' => 'link',
-                    '#title' => t('Web of Science citations: @cites', ['@cites' => $times_cited]),
+                    '#title' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
                     '#href' => $citing_articles_url,
-                    '#options' => [
+                    '#options' => array(
                       'target' => '_blank',
-                    ],
-                  ];
+                    ),
+                  );
                 }
                 else {
-                  $img = [
+                  $img = array(
                     '#theme' => 'image',
                     '#path' => format_string(
                       'https://img.shields.io/badge/Web%20of%20Science%20citations-!times_cited-orange.svg?style=flat',
-                      ['!times_cited' => $times_cited]
+                      array('!times_cited' => $times_cited)
                     ),
-                    '#alt' => t('Web of Science citations: @cites', ['@cites' => $times_cited]),
-                  ];
-                  $badge = [
+                    '#alt' => t('Web of Science citations: @cites', array('@cites' => $times_cited)),
+                  );
+                  $badge = array( 
                     '#type' => 'link',
                     '#title' => drupal_render($img),
                     '#href' => $citing_articles_url,
-                    '#options' => [
+                    '#options' => array( 
                       'target' => '_blank',
                       'html' => TRUE,
-                    ],
-                  ];
+                    ),
+                  );
 
                 }
-                $to_render['content']['islandora_wos'] = [
+                $to_render['content']['islandora_wos'] = array(
                   '#type' => 'container',
-                  '#attributes' => [
+                  '#attributes' => array(
                     'class' => 'islandora_wos_embed',
-                  ],
+                  ),
                   'badge' => $badge,
-                ];
+                );
               }
             }
           }


### PR DESCRIPTION
# What does this Pull Request do?
Reverts to old array syntax `array(1, 2, 3)` instead of shortened syntax `[1, 2, 3]` to maintain compatibility with PHP 5.3. I know that we don't HAVE to do this, but its an easy change that allows folks (like me) who can't update their PHP version to still use islandora_badges.

# What's new?
All arrays using the shortened syntax in islandora_wos.module and islandora_scopus.module have been updated to use the standard syntax.

# How should this be tested?
Fire up badges, swap in this PR code, and make sure WoS and SCOPUS work as expected.

# Interested parties
@bondjimbond @DiegoPino @dannylamb 