### PR TITLE
Adds version data to .info files

### DIFF
--- a/islandora_badges.info
+++ b/islandora_badges.info
@@ -1,4 +1,5 @@
 name = Islandora Badges
+version = 7.x-dev
 core = 7.x
 description = Islandora Badges integration.
 dependencies[] = islandora

--- a/modules/islandora_altmetrics/islandora_altmetrics.info
+++ b/modules/islandora_altmetrics/islandora_altmetrics.info
@@ -1,4 +1,5 @@
 name = Islandora Altmetrics Badge
+version = 7.x-dev
 core = 7.x
 description = Islandora Altmetrics integration.
 dependencies[] = islandora_badges

--- a/modules/islandora_crossref_citations/islandora_crossref_citations.info
+++ b/modules/islandora_crossref_citations/islandora_crossref_citations.info
@@ -1,4 +1,5 @@
 name = Islandora Crossref Citations
+version = 7.x-dev
 core = 7.x
 description = Islandora Crossref citation counts.
 dependencies[] = islandora_badges

--- a/modules/islandora_oadoi/islandora_oadoi.info
+++ b/modules/islandora_oadoi/islandora_oadoi.info
@@ -1,4 +1,5 @@
 name = Islandora oaDOI (Deprecated)
+version = 7.x-dev
 core = 7.x
 description = Islandora oaDOI linking - Deprecated in favour of Islandora Unpaywall (islandora_unpaywall).
 dependencies[] = islandora_badges

--- a/modules/islandora_scopus/islandora_scopus.info
+++ b/modules/islandora_scopus/islandora_scopus.info
@@ -1,4 +1,5 @@
 name = Islandora Scopus Badge
+version = 7.x-dev
 core = 7.x
 description = Islandora Scopus integration.
 dependencies[] = islandora_badges

--- a/modules/islandora_unpaywall/islandora_unpaywall.info
+++ b/modules/islandora_unpaywall/islandora_unpaywall.info
@@ -1,4 +1,5 @@
 name = Islandora Unpaywall
+version = 7.x-dev
 core = 7.x
 description = Islandora Unpaywall linking.
 dependencies[] = islandora_badges

--- a/modules/islandora_wos/islandora_wos.info
+++ b/modules/islandora_wos/islandora_wos.info
@@ -1,4 +1,5 @@
 name = Islandora Web of Science Badge
+version = 7.x-dev
 core = 7.x
 description = Islandora Web of Science integration.
 dependencies[] = islandora_badges


### PR DESCRIPTION
Simply adds version info to all .info files. Every .info file now has the following line:
`version = 7.x-dev`

Since this was missing from the module during release branch cutting, there was nothing to get updated and all info had to be manually added (found in commit https://github.com/Islandora/islandora_badges/commit/9368ef47b5fd5fd81a70973415e893bf96886607).

Nothing to test, this is pretty much just machine readable documentation.

Since this has already been implemented in the release branch, there doesn't need to be a second PR for it.

Attn: @bondjimbond 

