### PR TITLE
Add altmetric support for Handles and URIs

### DIFF
--- a/css/islandora_badges.admin.css
+++ b/css/islandora_badges.admin.css
@@ -1,7 +1,7 @@
 /* Admin style sheet for islandora badges */
 
 /* drag handler placeholder cell */
-.islandora-solr-multiple-drag
+.islandora-badges-multiple-drag
 {
   width: 30px;
 }

--- a/css/islandora_badges.admin.css
+++ b/css/islandora_badges.admin.css
@@ -1,0 +1,27 @@
+/* Admin style sheet for islandora badges */
+
+/* drag handler placeholder cell */
+.islandora-solr-multiple-drag
+{
+  width: 30px;
+}
+
+.form-item .islandora-badges-identifiers-header
+{
+  width: 35%;
+}
+
+html.js table span.tabledrag-changed
+{
+  position: absolute;
+}
+
+html.js .islandora-badges-identifiers-table .islandora-badges-identifier-field-weight
+{
+  display: none;
+}
+
+html.js .islandora-badges-identifiers-table .islandora-badges-identifier-field-weight.tabledrag-hide
+{
+  display: table-cell;
+}

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -82,7 +82,7 @@ function islandora_badges_admin_form($form, $form_settings) {
     '#theme' => 'islandora_badges_admin_identifier_fields',
   );
 
-  $terms = [];
+  $terms = array();
   foreach ($identifiers as $name => $value) {
     $terms[$name] = array(
       'draggable_handler' => array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Admin form functions for Islandora Altmetrics.
+ * Admin form functions for Islandora Badges.
  */
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -77,7 +77,7 @@ function islandora_badges_admin_form($form, $form_settings) {
   $form['islandora_badges_identifier_table'] = array(
     '#title' => t('Identifier Fields'),
     '#type' => 'item',
-    '#description' => t('MODS XPaths for retrieving identifier information. Set weights to change the order of identifiers to look for. DOI is first by default.'),
+    '#description' => t('MODS XPaths for retrieving identifier information. Set weights to change the order of identifiers to look for. DOI is first by default. Note that Xpaths are case-sensitive.'),
     '#tree' => TRUE,
     '#theme' => 'islandora_badges_admin_identifier_fields',
   );

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -6,21 +6,122 @@
  */
 
 /**
+ * Theme function to create an admin table for identifier fields.
+ *
+ * @param array $variables
+ *   Array containing form elements to be themed.
+ *
+ * @return string
+ *   Rendered table.
+ */
+function theme_islandora_badges_admin_identifier_fields(array $variables) {
+
+  $form = $variables['form'];
+
+  $rows = array();
+  foreach ($form['terms'] as $key => $element) {
+    if (is_array($element) && element_child($key)) {
+      $row = array();
+      $row[] = array('data' => drupal_render($form['terms'][$key]['draggable_handler']), 'class' => 'islandora-badges-multiple-drag');
+      $row[] = array('data' => drupal_render($form['terms'][$key]['name']));
+      $row[] = array('data' => drupal_render($form['terms'][$key]['xpath']));
+      $row[] = array('data' => drupal_render($form['terms'][$key]['weight']));
+
+      $rows[] = array('data' => $row, 'class' => array('draggable'));
+    }
+  }
+
+  // Create header array.
+  $header = array();
+  $header[] = array(
+    'data' => t('Name'),
+    'colspan' => 2,
+    'clas' => 'islandora-badges-identifier-field-header',
+  );
+  $header[] = array('data' => t('XPath'));
+  $header[] = array('data' => t('Weight'), 'class' => 'islandora-badges-identifier-field-weight');
+
+  $output = '';
+  $output .= theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+    'attributes' => array(
+      'id' => 'islandora-badges-identifiers',
+      'class' => array('islandora-badges-identifiers-table'),
+    ),
+  ));
+  $output .= drupal_render_children($form);
+  drupal_add_tabledrag('islandora-badges-identifiers', 'order', 'sibling', 'islandora-badges-identifiers-weight');
+  return $output;
+}
+
+/**
  * Admin form for Islandora Badges.
  */
 function islandora_badges_admin_form($form, $form_settings) {
+  // Add admin form css.
+  $form['#attached'] = array(
+    'css' => array(
+      drupal_get_path('module', 'islandora_badges') . '/css/islandora_badges.admin.css',
+    ),
+  );
+
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   $all_cmodels = islandora_get_content_models();
   $already_chosen = variable_get('islandora_badges_selected_cmodels', array('ir:citationCModel', 'ir:thesisCModel'));
   $selected_rows = drupal_map_assoc($already_chosen);
 
-  $form['islandora_badges_doi_xpath'] = array(
-    '#type' => 'textfield',
-    '#title' => t('DOI XPath'),
-    '#description' => t('MODS XPath for retrieving the DOI. Note that XPATH is case sensitive.'),
-    '#default_value' => variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]'),
+  $identifiers = array(
+    'doi' => array(
+      'xpath' => variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]'),
+      'weight' => variable_get('islandora_badges_doi_weight', 0),
+    ),
+    'handle' => array(
+      'xpath' => variable_get('islandora_badges_hdl_xpath', '/mods:mods/mods:identifier[@type="hdl"]'),
+      'weight' => variable_get('islandora_badges_hdl_weight', 1),
+    ),
+    'uri' => array(
+      'xpath' => variable_get('islandora_badges_uri_xpath', '/mods:mods/mods:identifier[@type="uri"]'),
+      'weight' => variable_get('islandora_badges_uri_weight', 2)
+    ),
   );
+  // Sort by weight.
+  uasort($identifiers, function($a, $b) {
+    return $a['weight'] - $b['weight'];
+  });
+
+  $form['islandora_badges_identifier_table'] = array(
+    '#title' => t('Identifier Fields'),
+    '#type' => 'item',
+    '#description' => t('MODS XPaths for retrieving identifier information. Set weights to change the order of identifiers to look for. DOI is first by default.'),
+    '#tree' => TRUE,
+    '#theme' => 'islandora_badges_admin_identifier_fields',
+  );
+
+  $terms = [];
+  foreach ($identifiers as $name => $value) {
+    $terms[$name] = array(
+      'draggable_handler' => array(
+        '#type' => 'item',
+        '#markup' => '',
+      ),
+      'name' => array(
+        '#type' => 'item',
+        '#markup' => $name,
+      ),
+      'xpath' => array(
+        '#type' => 'textfield',
+        '#default_value' => $value['xpath'],
+      ),
+      'weight' => array(
+        '#type' => 'weight',
+        '#default_value' => $value['weight'],
+        '#attributes' => array('class' => array('islandora-badges-identifiers-weight')),
+      ),
+    );
+  }
+  $form['islandora_badges_identifier_table']['terms'] = $terms;
 
   $form['content_model_wrapper'] = array(
     '#type' => 'fieldset',
@@ -69,13 +170,6 @@ function islandora_badges_admin_form($form, $form_settings) {
  *   The Drupal form state.
  */
 function islandora_badges_admin_form_validate(array $form, array &$form_state) {
-  if (!isset($form_state['values']['islandora_badges_doi_xpath']) ||
-    empty($form_state['values']['islandora_badges_doi_xpath'])) {
-    form_set_error(
-      'islandora_badges_doi_xpath',
-      t('You must set the XPath to find the DOI identifier in your MODS.')
-    );
-  }
   if (!array_keys(array_filter($form_state['values']['badges_table']))) {
     form_set_error(
       'badges_table',
@@ -90,6 +184,12 @@ function islandora_badges_admin_form_validate(array $form, array &$form_state) {
 function islandora_badges_admin_form_submit(array $form, array &$form_state) {
   $enabled = array_keys(array_filter($form_state['values']['badges_table']));
   variable_set('islandora_badges_selected_cmodels', $enabled);
-  variable_set('islandora_badges_doi_xpath', $form_state['values']['islandora_badges_doi_xpath']);
+
+  variable_set('islandora_badges_doi_xpath', $form_state['values']['islandora_badges_identifier_table']['terms']['doi']['xpath']);
+  variable_set('islandora_badges_hdl_xpath', $form_state['values']['islandora_badges_identifier_table']['terms']['handle']['xpath']);
+  variable_set('islandora_badges_uri_xpath', $form_state['values']['islandora_badges_identifier_table']['terms']['uri']['xpath']);
+  variable_set('islandora_badges_doi_weight', $form_state['values']['islandora_badges_identifier_table']['terms']['doi']['weight']);
+  variable_set('islandora_badges_hdl_weight', $form_state['values']['islandora_badges_identifier_table']['terms']['handle']['weight']);
+  variable_set('islandora_badges_uri_weight', $form_state['values']['islandora_badges_identifier_table']['terms']['uri']['weight']);
   drupal_set_message(t("Configuration saved."));
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -77,7 +77,7 @@ function islandora_badges_admin_form($form, $form_settings) {
   $form['islandora_badges_identifier_table'] = array(
     '#title' => t('Identifier Fields'),
     '#type' => 'item',
-    '#description' => t('MODS XPaths for retrieving identifier information. Set weights to change the order of identifiers to look for. DOI is first by default. Note that Xpaths are case-sensitive.'),
+    '#description' => t('MODS XPaths for retrieving identifier information. Set weights to change the order of identifiers to look for. DOI is first by default. Note that XPaths are case-sensitive.'),
     '#tree' => TRUE,
     '#theme' => 'islandora_badges_admin_identifier_fields',
   );

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -67,30 +67,13 @@ function islandora_badges_admin_form($form, $form_settings) {
   );
 
   module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora_badges', 'includes/utilities');
 
   $all_cmodels = islandora_get_content_models();
   $already_chosen = variable_get('islandora_badges_selected_cmodels', array('ir:citationCModel', 'ir:thesisCModel'));
   $selected_rows = drupal_map_assoc($already_chosen);
 
-  $identifiers = array(
-    'doi' => array(
-      'xpath' => variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]'),
-      'weight' => variable_get('islandora_badges_doi_weight', 0),
-    ),
-    'handle' => array(
-      'xpath' => variable_get('islandora_badges_hdl_xpath', '/mods:mods/mods:identifier[@type="hdl"]'),
-      'weight' => variable_get('islandora_badges_hdl_weight', 1),
-    ),
-    'uri' => array(
-      'xpath' => variable_get('islandora_badges_uri_xpath', '/mods:mods/mods:identifier[@type="uri"]'),
-      'weight' => variable_get('islandora_badges_uri_weight', 2)
-    ),
-  );
-  // Sort by weight.
-  uasort($identifiers, function($a, $b) {
-    return $a['weight'] - $b['weight'];
-  });
-
+  $identifiers = islandora_badges_get_identifier_types();
   $form['islandora_badges_identifier_table'] = array(
     '#title' => t('Identifier Fields'),
     '#type' => 'item',

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -6,7 +6,96 @@
  */
 
 /**
+ * Get and return an array of the identifier types.
+ *
+ * @return array
+ *   An associative array of identifiers. Each element
+ *   contains 'weight' and 'xpath' keys with the
+ *   corresponding variables for that identifier.
+ */
+function islandora_badges_get_identifier_types() {
+  $identifiers = array(
+    'doi' => array(
+      'xpath' => variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]'),
+      'weight' => variable_get('islandora_badges_doi_weight', 0),
+    ),
+    'handle' => array(
+      'xpath' => variable_get('islandora_badges_hdl_xpath', '/mods:mods/mods:identifier[@type="hdl"]'),
+      'weight' => variable_get('islandora_badges_hdl_weight', 1),
+    ),
+    'uri' => array(
+      'xpath' => variable_get('islandora_badges_uri_xpath', '/mods:mods/mods:identifier[@type="uri"]'),
+      'weight' => variable_get('islandora_badges_uri_weight', 2),
+    ),
+  );
+  // Sort by weight.
+  uasort($identifiers, function ($a, $b) {
+    return $a['weight'] - $b['weight'];
+  });
+
+  return $identifiers;
+}
+
+/**
+ * Get the identifier value for the given object, identifier and xpath.
+ *
+ * @param \AbstractObject $object
+ *   The Fedora object.
+ * @param string $identifier_type
+ *   The identifier type to find the value for. Corresponds to a key returned in
+ *   islandora_badges_get_identifier_types().
+ * @param string $identifier_xpath
+ *   The xpath expression to query.
+ *
+ * @return string
+ *   The value of the node or FALSE.
+ */
+function islandora_badges_get_identifier_value(AbstractObject $object, $identifier_type, $identifier_xpath) {
+  $node_value = islandora_badges_get_xpath_node_value($object, $identifier_xpath);
+  if ($node_value && $identifier_type == 'handle') {
+    // Need to strip the handle URL bit.
+    return str_replace('http://hdl.handle.net/', '', $node_value);
+  }
+  else {
+    return $node_value;
+  }
+}
+
+/**
+ * Find the value in the MODS corresponding to the given xpath.
+ *
+ * @param \AbstractObject $object
+ *   The Fedora object.
+ * @param string $xpath
+ *   The xpath expression to query.
+ *
+ * @return string
+ *   The value of the node or FALSE.
+ */
+function islandora_badges_get_xpath_node_value(AbstractObject $object, $xpath) {
+  if (!isset($object['MODS'])) {
+    return FALSE;
+  }
+  $doc = new DOMDocument();
+  $doc->loadXML($object['MODS']->content);
+  $domxpath = new DOMXPath($doc);
+  $domxpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+  $xpath_results = $domxpath->query($xpath);
+  if ($xpath_results->length == 0) {
+    return FALSE;
+  }
+  $value = $xpath_results->item(0)->nodeValue;
+  if (!$value) {
+    return FALSE;
+  }
+  return $value;
+}
+
+/**
  * Find a DOI in the MODS record and return it.
+ *
+ * Prefer islandora_badges_get_identifier_value().
+ * This is for backwards compatibility.
  *
  * @param \AbstractObject $object
  *   The Fedora object.
@@ -15,25 +104,8 @@
  *   The DOI or FALSE
  */
 function islandora_badges_get_doi(AbstractObject $object) {
-  // Get DOI.
-  if (!isset($object['MODS'])) {
-    return FALSE;
-  }
-  $doc = new DOMDocument();
-  $doc->loadXML($object['MODS']->content);
-  $xpath = new DOMXPath($doc);
-  $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-  $xpath_results = $xpath->query(
-    variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]')
-  );
-  if ($xpath_results->length == 0) {
-    return FALSE;
-  }
-  $doi = $xpath_results->item(0)->nodeValue;
-  if (!$doi) {
-    return FALSE;
-  }
-  return $doi;
+  $doi_xpath = variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]');
+  return islandora_badges_get_xpath_node_value($object, $doi_xpath);
 }
 
 /**

--- a/islandora_badges.install
+++ b/islandora_badges.install
@@ -11,6 +11,11 @@
 function islandora_badges_uninstall() {
   $vars = array(
     'islandora_badges_doi_xpath',
+    'islandora_badges_hdl_xpath',
+    'islandora_badges_uri_xpath',
+    'islandora_badges_doi_weight',
+    'islandora_badges_hdl_weight',
+    'islandora_badges_uri_weight',
     'islandora_badges_selected_cmodels',
   );
   array_walk($vars, 'variable_del');

--- a/islandora_badges.module
+++ b/islandora_badges.module
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Implements hook_theme().
+ */
+function islandora_badges_theme() {
+  $path = drupal_get_path('module', 'islandora_badges');
+  return array(
+    'islandora_badges_admin_identifier_fields' => array(
+      'path' => $path,
+      'file' => 'includes/admin.form.inc',
+      'render element' => 'form',
+    ),
+  );
+}
+
+/**
  * Implements hook_menu().
  */
 function islandora_badges_menu() {

--- a/modules/islandora_altmetrics/islandora_altmetrics.module
+++ b/modules/islandora_altmetrics/islandora_altmetrics.module
@@ -53,7 +53,7 @@ function islandora_altmetrics_block_view($delta) {
           if ($id_value) {
             // Only generate block if a result exists - check API callback.
             $altmetrics_api_url = 'http://api.altmetric.com/v1/' . $id_type . '/' . $id_value . '?callback=my_callback';
-            $head_response = @drupal_http_request($altmetrics_api_url, array('method' => 'HEAD'));
+            $head_response = drupal_http_request($altmetrics_api_url, array('method' => 'HEAD'));
             if ($head_response->code != 404) {
               // Embed Altmetrics.
               $to_render['content']['altmetrics'] = array(

--- a/modules/islandora_altmetrics/islandora_altmetrics.module
+++ b/modules/islandora_altmetrics/islandora_altmetrics.module
@@ -47,24 +47,28 @@ function islandora_altmetrics_block_view($delta) {
     if ($object) {
       if (islandora_badges_show_for_cmodel($object)) {
         // Use new customizable list of cmodels.
-        $doi = islandora_badges_get_doi($object);
-        if ($doi) {
-          // Only generate block if a result exists - check API callback.
-          $file_headers = @get_headers("http://api.altmetric.com/v1/doi/" . $doi . "?callback=my_callback");
-          if ($file_headers['0'] != 'HTTP/1.1 404 Not Found') {
-            // Embed Altmetrics.
-            $to_render['content']['altmetrics'] = array(
-              '#type' => 'container',
-              '#attributes' => array(
-                'class' => array('altmetric-embed'),
-                'data-badge-type' => variable_get('islandora_altmetrics_badge', 'Default'),
-                'data-doi' => $doi,
-                'data-badge-popover' => variable_get('islandora_altmetrics_popover', 'right'),
-                'data-hide-no-mentions' => 'true',
-                'data-link-target' => '_blank',
-              ),
-            );
-            drupal_add_js('https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js', 'external');
+        foreach (islandora_badges_get_identifier_types() as $id_type => $id_vars) {
+          $id_xpath = $id_vars['xpath'];
+          $id_value = islandora_badges_get_identifier_value($object, $id_type, $id_xpath);
+          if ($id_value) {
+            // Only generate block if a result exists - check API callback.
+            $file_headers = @get_headers("http://api.altmetric.com/v1/" . $id_type . "/" . $id_value . "?callback=my_callback");
+            if ($file_headers['0'] != 'HTTP/1.1 404 Not Found') {
+              // Embed Altmetrics.
+              $to_render['content']['altmetrics'] = array(
+                '#type' => 'container',
+                '#attributes' => array(
+                  'class' => array('altmetric-embed'),
+                  'data-badge-type' => variable_get('islandora_altmetrics_badge', 'Default'),
+                  'data-' . $id_type => $id_value,
+                  'data-badge-popover' => variable_get('islandora_altmetrics_popover', 'right'),
+                  'data-hide-no-mentions' => 'true',
+                  'data-link-target' => '_blank',
+                ),
+              );
+              drupal_add_js('https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js', 'external');
+              break;
+            }
           }
         }
       }

--- a/modules/islandora_altmetrics/islandora_altmetrics.module
+++ b/modules/islandora_altmetrics/islandora_altmetrics.module
@@ -52,8 +52,9 @@ function islandora_altmetrics_block_view($delta) {
           $id_value = islandora_badges_get_identifier_value($object, $id_type, $id_xpath);
           if ($id_value) {
             // Only generate block if a result exists - check API callback.
-            $file_headers = @get_headers("http://api.altmetric.com/v1/" . $id_type . "/" . $id_value . "?callback=my_callback");
-            if ($file_headers['0'] != 'HTTP/1.1 404 Not Found') {
+            $altmetrics_api_url = 'http://api.altmetric.com/v1/' . $id_type . '/' . $id_value . '?callback=my_callback';
+            $head_response = @drupal_http_request($altmetrics_api_url, array('method' => 'HEAD'));
+            if ($head_response->code != 404) {
               // Embed Altmetrics.
               $to_render['content']['altmetrics'] = array(
                 '#type' => 'container',

--- a/modules/islandora_altmetrics/islandora_altmetrics.module
+++ b/modules/islandora_altmetrics/islandora_altmetrics.module
@@ -54,7 +54,7 @@ function islandora_altmetrics_block_view($delta) {
             // Only generate block if a result exists - check API callback.
             $altmetrics_api_url = 'http://api.altmetric.com/v1/' . $id_type . '/' . $id_value . '?callback=my_callback';
             $head_response = drupal_http_request($altmetrics_api_url, array('method' => 'HEAD'));
-            if ($head_response->code != 404) {
+            if ($head_response->code == 200) {
               // Embed Altmetrics.
               $to_render['content']['altmetrics'] = array(
                 '#type' => 'container',


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2374](https://jira.duraspace.org/browse/ISLANDORA-2374)

# What does this Pull Request do?

The altmetrics module currently only supports DOI identifiers when creating altmetric badges. The altmetric API has support for many other identifier types; this PR adds support for handles and URIs. By default, DOIs will still take precendence, but this is configurable in the admin.

# What's new?

* Add a draggable table to badges admin form for identifier weight/xpath configuration.
* Add new variables for handle xpath, doi xpath, and weights.
* Changes to altmetrics badge block to loop through the identifier types.

# How should this be tested?

Testing basic behaviour:
  * Add altmetrics block to somewhere visible
  * In badges configuration:
    * Add cmodel you'll be testing with to the "display badges list"
  * Ingest object that will display a badge.
  * Replace MODS datastreams with the following examples containing DOI, handle and URI respectively.
      https://gist.github.com/mghughes/1ff31ef4d85344354b8e204703db0227
      https://gist.github.com/mghughes/e5c1c4c9e674692fd9554a5808246af8
      https://gist.github.com/mghughes/9f354c88917b04c37c7b6b196dce1b4a
  * Ensure badge displays and link corresponds to identifier in MODS.

Testing ordering:
  * In badges admin coniguration, play around with ordering of identifier types.
  * Ingest an object that will display a badge.
  * Replace MODS datastream with the following (contains all 3 identifier types)
      https://gist.github.com/mghughes/edd5c502a47efb559d9a4cdce45e479e
  * Ensure badge displays and corresponds to first identifier
  * Repeat, changing order and which identifiers present in MODS.

TESTING XPaths:
  Xpath retrieval code is the same as before, but for completeness it wouldn't hurt to test this
  * In badges admin configuration, change the values of the xpath text fields
  * Change identifier locations in sample MODS file to correspond to the values given
  * Ingest object, replace MODS with altered sample MODS
  * Ensure badge displays and links correctly

# Additional Notes:
Variables have been added individually for each identifier xpath and weight, which seemed most straightforward in order to not break existing install which use the "doi_xpath" variable. But it may be worth considering just saving a blob instead? Open to ideas here.

# Interested parties
@bondjimbond 
