### PR TITLE
DOIs shouldn't say doi:

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -56,6 +56,10 @@ function islandora_badges_get_identifier_value(AbstractObject $object, $identifi
     // Need to strip the handle URL bit.
     return str_replace('http://hdl.handle.net/', '', $node_value);
   }
+  elseif ($node_value && $identifier_type == 'doi' && strpos(strtolower($node_value), 'doi:') === 0) {
+    // If you have doi: at the start of your doi, remove it.
+    return substr($node_value, 4);
+  }
   else {
     return $node_value;
   }
@@ -97,6 +101,8 @@ function islandora_badges_get_xpath_node_value(AbstractObject $object, $xpath) {
  * Prefer islandora_badges_get_identifier_value().
  * This is for backwards compatibility.
  *
+ * @deprecated Use islandora_badges_get_identifier_value() instead.
+ *
  * @param \AbstractObject $object
  *   The Fedora object.
  *
@@ -105,7 +111,7 @@ function islandora_badges_get_xpath_node_value(AbstractObject $object, $xpath) {
  */
 function islandora_badges_get_doi(AbstractObject $object) {
   $doi_xpath = variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]');
-  return islandora_badges_get_xpath_node_value($object, $doi_xpath);
+  return islandora_badges_get_identifier_value($object, 'doi', $doi_xpath);
 }
 
 /**


### PR DESCRIPTION
Really deprecate the function

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2457

# What does this Pull Request do?

If you have added `doi:` to the front of your DOI then we need to remove it or it is invalid and fails some searches.

Also deprecate the `islandora_badges_get_doi` function and point it to use the preferred `islandora_badges_get_identifier_value` function.

# How should this be tested?

Make a DOI with the form like in the ticket and this should remove the doi: prefix and therefore succeed in getting you Scopus results.

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers @bondjimbond @bradspry
