### PR TITLE
Update README.md to fix a heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ These modules provide the actual badges:
 * [Islandora Unpaywall](modules/islandora_unpaywall/)
 * [Islandora Crossref Citations](modules/islandora_crossref_citations)
 
-##Documentation
+## Documentation
 
 Further documentation for this module is available at https://wiki.duraspace.org/x/bhpsBQ
 


### PR DESCRIPTION
**JIRA Ticket**: (none - minor documentation issue)

# What does this Pull Request do?

Fixes the heading on the Documentation section on the readme so that the markdown works.

# What's new?

`##Documentation` needs a space. `## Documentation` will display properly as a heading.

# How should this be tested?

Preview the text and verify that the heading now appears as a heading.


# Interested parties
@DonRichards  @whikloj 